### PR TITLE
Expose helper exports and add self-tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ npm install --save-dev @rayners/foundry-dev-tools
 
 ## Usage
 
+All of the runtime helpers are re-exported from the package entry point, so a single `@rayners/foundry-dev-tools` import covers Rollup builders, Vitest presets, and the Sentry utilities described below.
+
 ### Rollup Configuration
 
 Create or update your `rollup.config.js`:
@@ -45,7 +47,7 @@ Create or update your `tsconfig.json`:
 
 ```json
 {
-  "extends": "@rayners/foundry-dev-tools/configs/tsconfig.base.json",
+  "extends": "@rayners/foundry-dev-tools/tsconfig",
   "compilerOptions": {
     "types": ["jquery"],
     "typeRoots": ["./node_modules/@types", "./src/types"]
@@ -55,27 +57,31 @@ Create or update your `tsconfig.json`:
 
 ### ESLint Configuration
 
-Create or update your `.eslintrc.json`:
+Create or update `eslint.config.js`:
 
-```json
-{
-  "extends": ["@rayners/foundry-dev-tools/configs/eslint"]
-}
+```javascript
+import foundryConfig from '@rayners/foundry-dev-tools/eslint';
+
+export default [
+  ...foundryConfig
+];
 ```
+
+> **Type-aware linting requires a project file.** The shared preset enables `parserOptions.project`, so make sure a `tsconfig.json` exists at your project root (or adjust the option before exporting).
 
 ### Prettier Configuration
 
 Create `prettier.config.js`:
 
 ```javascript
-export { default } from '@rayners/foundry-dev-tools/configs/prettier.config.js';
+export { default } from '@rayners/foundry-dev-tools/prettier';
 ```
 
 Or add to your `package.json`:
 
 ```json
 {
-  "prettier": "@rayners/foundry-dev-tools/configs/prettier.config.js"
+  "prettier": "@rayners/foundry-dev-tools/prettier"
 }
 ```
 
@@ -84,7 +90,7 @@ Or add to your `package.json`:
 Create or update your `vitest.config.ts`:
 
 ```javascript
-import { createFoundryTestConfig } from '@rayners/foundry-dev-tools/configs/vitest.config.js';
+import { createFoundryTestConfig } from '@rayners/foundry-dev-tools';
 
 export default createFoundryTestConfig();
 ```
@@ -106,6 +112,32 @@ export default createFoundryTestConfig({
 });
 ```
 
+Need CI-friendly output?
+
+```javascript
+import { createFoundryTestConfigWithJUnit } from '@rayners/foundry-dev-tools';
+
+export default createFoundryTestConfigWithJUnit();
+```
+
+> The shared preset automatically includes `./test/setup.ts` when the file exists. Projects without that helper can use the preset as-is—Vitest will receive an empty `setupFiles` array.
+
+### Sentry Sourcemap Uploads
+
+The Sentry helpers are also available from the package entry point:
+
+```javascript
+import { createSentryConfig } from '@rayners/foundry-dev-tools';
+
+export default {
+  plugins: [
+    createSentryConfig('my-module', process.env.MODULE_VERSION)
+  ]
+};
+```
+
+Uploads only run when `UPLOAD_SOURCE_MAPS` is truthy and `SENTRY_AUTH_TOKEN` is present, making it safe to keep the plugin wired into local builds. For CI smoke tests, use `createSentryTestConfig` to keep the release plugin registered without attempting an upload.
+
 ## Features
 
 - **Standardized Rollup Configuration**: Automatic SCSS compilation, file copying, and GitHub release URL injection
@@ -113,6 +145,7 @@ export default createFoundryTestConfig({
 - **ESLint Rules**: Foundry-specific globals and TypeScript best practices
 - **Prettier Formatting**: Consistent code formatting across all modules
 - **Vitest Testing**: Pre-configured for FoundryVTT module testing with jsdom environment
+- **Sentry Integration**: Optional helpers to upload release sourcemaps only when CI variables are present
 - **Development Server**: Built-in dev server with live reload for faster development
 
 ## Configuration Options
@@ -120,6 +153,7 @@ export default createFoundryTestConfig({
 ### Rollup Options
 
 - `cssFileName`: **Required** - Output path for compiled CSS
+- `input`: Override the Rollup entry file (default: `src/module.ts`)
 - `additionalCopyTargets`: Additional files to copy to dist
 - `scssOptions`: Override SCSS plugin options
 - `typescriptOptions`: Override TypeScript plugin options  
@@ -150,6 +184,10 @@ After installing, you can remove these duplicate dependencies from your modules:
   }
 }
 ```
+
+### Foundry Type Definitions
+
+The bundled `types/foundry-v13-essentials.d.ts` file intentionally covers a "minimal but complete" slice of the Foundry VTT v13 API. Check for upstream changes whenever Foundry ships a new major release so your modules continue to receive accurate type hints (and feel free to contribute updates back here!).
 
 ## GitHub Packages
 

--- a/configs/eslint.config.js
+++ b/configs/eslint.config.js
@@ -9,14 +9,30 @@
  */
 
 import eslint from '@eslint/js';
+import eslintConfigPrettier from 'eslint-config-prettier/flat';
+import prettierPlugin from 'eslint-plugin-prettier';
 import tseslint from 'typescript-eslint';
 
 export default [
   // Base JS rules
   eslint.configs.recommended,
-  
+
   // TypeScript rules for TS files
   ...tseslint.configs.recommended,
+
+  // Disable stylistic rules that conflict with Prettier
+  eslintConfigPrettier,
+
+  // Surface Prettier formatting issues as lint warnings
+  {
+    name: 'foundry-prettier',
+    plugins: {
+      prettier: prettierPlugin
+    },
+    rules: {
+      'prettier/prettier': 'warn'
+    }
+  },
   
   // Custom Foundry VTT configuration
   {
@@ -75,7 +91,7 @@ export default [
       
       // TypeScript-specific relaxed rules for Foundry development
       "@typescript-eslint/no-explicit-any": "warn",
-      "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+      "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
     }
   },
   

--- a/configs/vitest.config.js
+++ b/configs/vitest.config.js
@@ -1,3 +1,5 @@
+import { existsSync } from 'fs';
+import { resolve } from 'path';
 import { defineConfig } from 'vitest/config';
 
 /**
@@ -17,40 +19,49 @@ import { defineConfig } from 'vitest/config';
  * });
  */
 
-const defaultConfig = {
-  test: {
-    environment: 'jsdom',
-    globals: true,
-    setupFiles: ['./test/setup.ts'],
-    reporters: ['default'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html', 'lcov'],
-      exclude: [
-        'node_modules/',
-        'test/',
-        'dist/',
-        '**/*.d.ts',
-        '*.config.*',
-        'docs/',
-        'templates/',
-        'styles/',
-        'calendars/',
-        'languages/',
-        'assets/',
-        'scripts/'
-      ],
-      thresholds: {
-        global: {
-          branches: 80,
-          functions: 80,
-          lines: 80,
-          statements: 80
+const DEFAULT_SETUP_FILE = './test/setup.ts';
+
+function detectSetupFiles() {
+  const setupFilePath = resolve(process.cwd(), 'test/setup.ts');
+  return existsSync(setupFilePath) ? [DEFAULT_SETUP_FILE] : [];
+}
+
+function createDefaultTestConfig() {
+  return {
+    test: {
+      environment: 'jsdom',
+      globals: true,
+      setupFiles: detectSetupFiles(),
+      reporters: ['default'],
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'json', 'html', 'lcov'],
+        exclude: [
+          'node_modules/',
+          'test/',
+          'dist/',
+          '**/*.d.ts',
+          '*.config.*',
+          'docs/',
+          'templates/',
+          'styles/',
+          'calendars/',
+          'languages/',
+          'assets/',
+          'scripts/'
+        ],
+        thresholds: {
+          global: {
+            branches: 80,
+            functions: 80,
+            lines: 80,
+            statements: 80
+          }
         }
       }
     }
-  }
-};
+  };
+}
 
 /**
  * Create a Vitest configuration for FoundryVTT modules
@@ -58,11 +69,14 @@ const defaultConfig = {
  * @returns {Object} Vitest configuration
  */
 export function createFoundryTestConfig(customConfig = {}) {
+  const defaultConfig = createDefaultTestConfig();
+
   return defineConfig({
     ...defaultConfig,
     test: {
       ...defaultConfig.test,
       ...customConfig.test,
+      setupFiles: customConfig.test?.setupFiles ?? defaultConfig.test.setupFiles,
       reporters: customConfig.test?.reporters || defaultConfig.test.reporters,
       coverage: {
         ...defaultConfig.test.coverage,
@@ -92,4 +106,4 @@ export function createFoundryTestConfigWithJUnit(customConfig = {}) {
 }
 
 // Export default config for direct use
-export default defineConfig(defaultConfig);
+export default defineConfig(createDefaultTestConfig());

--- a/index.js
+++ b/index.js
@@ -10,8 +10,17 @@ export {
   createFoundryConfigWithDir 
 } from './rollup/foundry-config.js';
 
-// Test configurations  
-export { createFoundryTestConfig } from './configs/vitest.config.js';
+// Test configurations
+export {
+  createFoundryTestConfig,
+  createFoundryTestConfigWithJUnit
+} from './configs/vitest.config.js';
+
+// Sentry helpers
+export {
+  createSentryConfig,
+  createSentryTestConfig
+} from './rollup/sentry-config.js';
 
 // Re-export config files for direct import
 export { default as eslintConfig } from './configs/eslint.config.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rayners/foundry-dev-tools",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rayners/foundry-dev-tools",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@eslint/js": "^9.18.0",
@@ -24,6 +24,9 @@
         "sass": "^1.62.0",
         "tslib": "^2.5.0",
         "typescript-eslint": "^8.19.0"
+      },
+      "devDependencies": {
+        "vitest": "^3.2.2"
       },
       "peerDependencies": {
         "eslint": "^9.0.0",
@@ -411,7 +414,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -428,7 +430,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -445,7 +446,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -462,7 +462,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -479,7 +478,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -496,7 +494,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -513,7 +510,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -530,7 +526,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -547,7 +542,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -564,7 +558,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -581,7 +574,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -598,7 +590,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -615,7 +606,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -632,7 +622,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -649,7 +638,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -666,7 +654,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -683,7 +670,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -700,7 +686,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -717,7 +702,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -734,7 +718,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -751,7 +734,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -768,7 +750,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -785,7 +766,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -802,7 +782,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -819,7 +798,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1563,8 +1541,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.43.0",
@@ -1577,8 +1554,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.43.0",
@@ -1591,8 +1567,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.43.0",
@@ -1605,8 +1580,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.43.0",
@@ -1619,8 +1593,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.43.0",
@@ -1633,8 +1606,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.43.0",
@@ -1647,8 +1619,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.43.0",
@@ -1661,8 +1632,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.43.0",
@@ -1675,8 +1645,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.43.0",
@@ -1689,8 +1658,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
       "version": "4.43.0",
@@ -1703,8 +1671,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
       "version": "4.43.0",
@@ -1717,8 +1684,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.43.0",
@@ -1731,8 +1697,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.43.0",
@@ -1745,8 +1710,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.43.0",
@@ -1759,8 +1723,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.43.0",
@@ -1773,8 +1736,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.43.0",
@@ -1787,8 +1749,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.43.0",
@@ -1801,8 +1762,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.43.0",
@@ -1815,8 +1775,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.43.0",
@@ -1829,8 +1788,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@sentry/babel-plugin-component-annotate": {
       "version": "3.5.0",
@@ -2025,7 +1983,6 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
       "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/deep-eql": "*"
       }
@@ -2034,8 +1991,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2393,7 +2349,6 @@
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.3.tgz",
       "integrity": "sha512-W2RH2TPWVHA1o7UmaFKISPvdicFJH+mjykctJFoAkUw+SPTJTGjUNdKscFBrqM7IPnCVu6zihtKYa7TkZS1dkQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/spy": "3.2.3",
@@ -2410,7 +2365,6 @@
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.3.tgz",
       "integrity": "sha512-cP6fIun+Zx8he4rbWvi+Oya6goKQDZK+Yq4hhlggwQBbrlOQ4qtZ+G4nxB6ZnzI9lyIb+JnvyiJnPC2AGbKSPA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/spy": "3.2.3",
         "estree-walker": "^3.0.3",
@@ -2437,7 +2391,6 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
@@ -2447,7 +2400,6 @@
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
       "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
@@ -2457,7 +2409,6 @@
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.3.tgz",
       "integrity": "sha512-yFglXGkr9hW/yEXngO+IKMhP0jxyFw2/qys/CK4fFUZnSltD+MU7dVYGrH8rvPcK/O6feXQA+EU33gjaBBbAng==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tinyrainbow": "^2.0.0"
       },
@@ -2470,7 +2421,6 @@
       "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.3.tgz",
       "integrity": "sha512-83HWYisT3IpMaU9LN+VN+/nLHVBCSIUKJzGxC5RWUOsK1h3USg7ojL+UXQR3b4o4UBIWCYdD2fxuzM7PQQ1u8w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.3",
         "pathe": "^2.0.3",
@@ -2485,7 +2435,6 @@
       "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.3.tgz",
       "integrity": "sha512-9gIVWx2+tysDqUmmM1L0hwadyumqssOL1r8KJipwLx5JVYyxvVRfxvMq7DaWbZZsCqZnu/dZedaZQh4iYTtneA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "3.2.3",
         "magic-string": "^0.30.17",
@@ -2500,7 +2449,6 @@
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
       "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
@@ -2510,7 +2458,6 @@
       "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.3.tgz",
       "integrity": "sha512-JHu9Wl+7bf6FEejTCREy+DmgWe+rQKbK+y32C/k5f4TBIAlijhJbRBIRIOCEpVevgRsCQR2iHRUH2/qKVM/plw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tinyspy": "^4.0.3"
       },
@@ -2523,7 +2470,6 @@
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.3.tgz",
       "integrity": "sha512-4zFBCU5Pf+4Z6v+rwnZ1HU1yzOKKvDkMXZrymE2PBlbjKJRlrOxbvpfPSvJTGRIwGoahaOGvp+kbCoxifhzJ1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "3.2.3",
         "loupe": "^3.1.3",
@@ -2657,7 +2603,6 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2765,7 +2710,6 @@
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2805,7 +2749,6 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
       "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "assertion-error": "^2.0.1",
         "check-error": "^2.1.1",
@@ -2839,7 +2782,6 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
       "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 16"
       }
@@ -2984,7 +2926,6 @@
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
       "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3076,8 +3017,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.5",
@@ -3085,7 +3025,6 @@
       "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3352,7 +3291,6 @@
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
       "integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -3426,7 +3364,6 @@
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
       "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -4214,8 +4151,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
       "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -4360,7 +4296,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -4624,15 +4559,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/pathval": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
       "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 14.16"
       }
@@ -4674,7 +4607,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4835,7 +4767,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.43.0.tgz",
       "integrity": "sha512-wdN2Kd3Twh8MAEOEJZsuxuLKCsBEo4PVNLK6tQWAn10VhsVewQLzcucMgLolRlhFybGxfclbPeEYBaP6RvUFGg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.7"
       },
@@ -4936,8 +4867,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
@@ -5068,8 +4998,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
@@ -5105,8 +5034,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "3.9.0",
@@ -5228,7 +5156,6 @@
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
       "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "js-tokens": "^9.0.1"
       },
@@ -5240,8 +5167,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -5359,22 +5285,19 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
       "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fdir": "^6.4.4",
         "picomatch": "^4.0.2"
@@ -5391,7 +5314,6 @@
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.0.tgz",
       "integrity": "sha512-7CotroY9a8DKsKprEy/a14aCCm8jYVmR7aFy4fpkZM8sdpNJbKkixuNjgM50yCmip2ezc8z4N7k3oe2+rfRJCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
       }
@@ -5410,7 +5332,6 @@
       "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
       "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -5608,7 +5529,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5683,7 +5603,6 @@
       "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.3.tgz",
       "integrity": "sha512-gc8aAifGuDIpZHrPjuHyP4dpQmYXqWw7D1GmDnWeNWP654UEXzVfQ5IHPSK5HaHkwB/+p1atpYpSdw/2kOv8iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cac": "^6.7.14",
         "debug": "^4.4.1",
@@ -5706,7 +5625,6 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.3.tgz",
       "integrity": "sha512-E6U2ZFXe3N/t4f5BwUaVCKRLHqUpk1CBWeMh78UT4VaTPH/2dyvH6ALl29JTovEPu9dVKr/K/J4PkXgrMbw4Ww==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.3",
@@ -5779,7 +5697,6 @@
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
       "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
@@ -5874,7 +5791,6 @@
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "siginfo": "^2.0.0",
         "stackback": "0.0.2"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "index.js"
   ],
   "scripts": {
-    "test": "echo \"No tests yet\"",
+    "test": "vitest run",
     "prepublishOnly": "echo \"Building shared configs...\"",
     "link-module": "node scripts/link-module.js"
   },
@@ -67,5 +67,8 @@
     "sass": "^1.62.0",
     "tslib": "^2.5.0",
     "typescript-eslint": "^8.19.0"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.2"
   }
 }

--- a/rollup/foundry-config.js
+++ b/rollup/foundry-config.js
@@ -56,6 +56,7 @@ const standardCopyTargets = [
  * 
  * @param {Object} options - Configuration options
  * @param {string} options.cssFileName - CSS output filename (e.g., 'styles/module-name.css')
+ * @param {string} [options.input] - Rollup entry file (default: 'src/module.ts')
  * @param {Array} [options.additionalCopyTargets] - Additional files to copy
  * @param {Object} [options.scssOptions] - Additional SCSS plugin options
  * @param {Object} [options.typescriptOptions] - Additional TypeScript plugin options
@@ -72,7 +73,8 @@ export function createFoundryConfig(options = {}) {
     typescriptOptions = {},
     useDevServer = process.env.SERVE === 'true',
     devServerPort = 30000,
-    outputFormat = 'es'
+    outputFormat = 'es',
+    input = 'src/module.ts'
   } = options;
 
   if (!cssFileName) {
@@ -124,7 +126,7 @@ export function createFoundryConfig(options = {}) {
   }
 
   return {
-    input: 'src/module.ts',
+    input,
     output,
     plugins: plugins.filter(Boolean) // Remove any undefined plugins
   };

--- a/test/foundry-config.test.js
+++ b/test/foundry-config.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { createFoundryConfig, createFoundryConfigWithDir } from '../rollup/foundry-config.js';
+
+describe('createFoundryConfig', () => {
+  it('uses the default entry when none is provided', () => {
+    const config = createFoundryConfig({ cssFileName: 'styles/module.css' });
+
+    expect(config.input).toBe('src/module.ts');
+    expect(config.output).toMatchObject({ file: 'dist/module.js', format: 'es' });
+  });
+
+  it('respects a custom entry file', () => {
+    const config = createFoundryConfig({
+      cssFileName: 'styles/module.css',
+      input: 'src/main.ts'
+    });
+
+    expect(config.input).toBe('src/main.ts');
+  });
+});
+
+describe('createFoundryConfigWithDir', () => {
+  it('returns a directory output configuration', () => {
+    const config = createFoundryConfigWithDir({ cssFileName: 'styles/module.css' });
+
+    expect(config.output).toMatchObject({ dir: 'dist', format: 'es' });
+  });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createFoundryConfig,
+  createFoundryConfigWithDir,
+  createFoundryTestConfig,
+  createFoundryTestConfigWithJUnit,
+  createSentryConfig,
+  createSentryTestConfig,
+  eslintConfig,
+  prettierConfig,
+  vitestConfig
+} from '../index.js';
+
+describe('package entry exports', () => {
+  it('exposes the rollup helpers', () => {
+    expect(typeof createFoundryConfig).toBe('function');
+    expect(typeof createFoundryConfigWithDir).toBe('function');
+  });
+
+  it('exposes the vitest helpers', () => {
+    expect(typeof createFoundryTestConfig).toBe('function');
+    expect(typeof createFoundryTestConfigWithJUnit).toBe('function');
+  });
+
+  it('exposes the sentry helpers', () => {
+    expect(typeof createSentryConfig).toBe('function');
+    expect(typeof createSentryTestConfig).toBe('function');
+  });
+
+  it('re-exports the shared configs', () => {
+    expect(eslintConfig).toBeDefined();
+    expect(prettierConfig).toBeDefined();
+    expect(vitestConfig).toBeDefined();
+  });
+});

--- a/test/vitest-config.test.js
+++ b/test/vitest-config.test.js
@@ -1,0 +1,53 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdir, rm, writeFile } from 'fs/promises';
+import { resolve } from 'path';
+
+const setupFilePath = resolve(process.cwd(), 'test/setup.ts');
+
+async function removeSetupFile() {
+  await rm(setupFilePath, { force: true });
+}
+
+describe('createFoundryTestConfig', () => {
+  beforeEach(async () => {
+    await removeSetupFile();
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    await removeSetupFile();
+    vi.resetModules();
+  });
+
+  afterAll(async () => {
+    await removeSetupFile();
+  });
+
+  it('omits setupFiles when the setup helper is missing', async () => {
+    const { createFoundryTestConfig } = await import('../configs/vitest.config.js');
+
+    const config = createFoundryTestConfig();
+
+    expect(config.test.environment).toBe('jsdom');
+    expect(config.test.setupFiles).toEqual([]);
+  });
+
+  it('includes setupFiles when the helper is present', async () => {
+    await mkdir(resolve(process.cwd(), 'test'), { recursive: true });
+    await writeFile(setupFilePath, 'export {}\n');
+
+    const { createFoundryTestConfig } = await import('../configs/vitest.config.js');
+
+    const config = createFoundryTestConfig();
+
+    expect(config.test.setupFiles).toEqual(['./test/setup.ts']);
+  });
+
+  it('adds the junit reporter helper', async () => {
+    const { createFoundryTestConfigWithJUnit } = await import('../configs/vitest.config.js');
+
+    const config = createFoundryTestConfigWithJUnit();
+
+    expect(config.test.reporters).toContainEqual(['junit', { outputFile: 'test-report.junit.xml' }]);
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,8 @@
+import { createFoundryTestConfig } from './index.js';
+
+export default createFoundryTestConfig({
+  test: {
+    include: ['test/**/*.test.js'],
+    environment: 'node'
+  }
+});


### PR DESCRIPTION
## Summary
- re-export the Vitest and Sentry helper factories from the package entry and allow the rollup preset to accept a custom input file
- make the shared Vitest preset detect optional setup files, document the streamlined import paths, and wire Prettier into the flat ESLint config
- add a Vitest suite plus repository config to smoke-test the exported helpers and update the npm test script to run it

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccdeae094c832793e0406472525328